### PR TITLE
Revert "Add a fake health endpoint to quickly fix an issue"

### DIFF
--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -7,16 +7,4 @@ module.exports = app => {
 		response.redirect(301, `${request.basePath}v2/`);
 	});
 
-	// TEMPORARY health
-	app.get('/__health.2', (request, response) => {
-		response.send({
-			"schemaVersion": 1,
-			"name": "origami-navigation-service",
-			"systemCode": "origami-navigation-service",
-			"description": "Provides consistent navigation for FT applications.",
-			"checks": [
-			]
-		});
-	});
-
 };


### PR DESCRIPTION
Reverts Financial-Times/origami-navigation-service#28

This can be merged once https://github.com/Financial-Times/ft.com-cdn/pull/301 hits production.