### PR TITLE
Don't specify a port for integration tests

### DIFF
--- a/test/integration/setup.js
+++ b/test/integration/setup.js
@@ -24,7 +24,7 @@ before(function() {
 				environment: 'test',
 				log: mockLog,
 				navigationDataStore: this.mockStore.address,
-				port: process.env.PORT || null,
+				port: null,
 				requestLogFormat: null
 			}).listen();
 		})


### PR DESCRIPTION
Otherwise a port in the .env file will override this, causing
integration tests to fail.