### PR TITLE
Add a links endpoint which responds with all links

### DIFF
--- a/lib/links-data.js
+++ b/lib/links-data.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Poller = require('ft-poller');
+
+module.exports = linksData;
+
+function linksData(config) {
+	validateConfig(config);
+	const dataStore = config.dataStore.replace(/\/+$/, '');
+	const version = config.version;
+	const url = `${dataStore}/v${version}/links.json`;
+	const refreshInterval = 60 * 1000; // one minute
+	return new Poller({
+		autostart: true,
+		refreshInterval,
+		url
+	});
+}
+
+function validateConfig(config) {
+	if (typeof config.dataStore !== 'string') {
+		throw new Error('dataStore must be a string');
+	}
+	if (typeof config.version !== 'number') {
+		throw new Error('version must be a number');
+	}
+}

--- a/lib/navigation-service.js
+++ b/lib/navigation-service.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const healthChecks = require('./health-checks');
+const linksData = require('./links-data');
 const navigationData = require('./navigation-data');
 const origamiService = require('@financial-times/origami-service');
 const requireAll = require('require-all');
@@ -21,6 +22,10 @@ function navigationService(options) {
 	app.use(origamiService.middleware.notFound());
 	app.use(origamiService.middleware.errorHandler());
 
+	app.linksDataV2 = linksData({
+		dataStore: options.navigationDataStore,
+		version: 2
+	});
 	app.navigationDataV2 = navigationData({
 		dataStore: options.navigationDataStore,
 		version: 2

--- a/lib/routes/v2/links.js
+++ b/lib/routes/v2/links.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const cacheControl = require('@financial-times/origami-service').middleware.cacheControl;
+const httpError = require('http-errors');
+const sourceParam = require('@financial-times/source-param-middleware');
+
+module.exports = app => {
+
+	const requireValidSourceParam = sourceParam({
+		verifyUsingCmdb: false
+	});
+
+	// v2 links endpoint
+	app.get(
+		'/v2/links',
+		requireValidSourceParam,
+		cacheControl({
+			maxAge: '10m',
+			staleIfError: '7d'
+		}),
+		(request, response, next) => {
+			const data = app.linksDataV2.getData();
+			if (!isValidLinksData(data)) {
+				return next(httpError(500, 'Links data is invalid'));
+			}
+			response.send(data);
+		}
+	);
+
+};
+
+function isValidLinksData(data) {
+	return Array.isArray(data);
+}

--- a/test/integration/mock/store.js
+++ b/test/integration/mock/store.js
@@ -7,6 +7,17 @@ module.exports = createMockStore;
 function createMockStore() {
 	const mockStore = express();
 
+	mockStore.get('/v2/links.json', (request, response) => {
+		response.send([
+			{
+				label: 'Link 1'
+			},
+			{
+				label: 'Link 2'
+			}
+		]);
+	});
+
 	mockStore.get('/v2/navigation.json', (request, response) => {
 		response.send({
 			menu1: {

--- a/test/integration/v2/links.js
+++ b/test/integration/v2/links.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const assert = require('proclaim');
+const itRespondsWithContentType = require('../helpers/it-responds-with-content-type');
+const itRespondsWithStatus = require('../helpers/it-responds-with-status');
+const setupRequest = require('../helpers/setup-request');
+
+describe('GET /v2/links', function() {
+
+	setupRequest('GET', '/v2/links?source=test');
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/json');
+
+	it('responds with the links JSON', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			const json = JSON.parse(response.text);
+			// Note: mock data can be found in ../mock/store.js
+			assert.deepEqual(json, [
+				{
+					label: 'Link 1'
+				},
+				{
+					label: 'Link 2'
+				}
+			]);
+		}).end(done);
+	});
+
+});

--- a/test/unit/lib/links-data.js
+++ b/test/unit/lib/links-data.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const assert = require('proclaim');
+const mockery = require('mockery');
+
+describe('lib/links-data', () => {
+	let linksData;
+	let Poller;
+
+	beforeEach(() => {
+		Poller = require('../mock/ft-poller.mock');
+		mockery.registerMock('ft-poller', Poller);
+
+		linksData = require('../../../lib/links-data');
+	});
+
+	it('exports a function', () => {
+		assert.isFunction(linksData);
+	});
+
+	describe('linksData(config)', () => {
+		let config;
+		let returnValue;
+
+		beforeEach(() => {
+			config = {
+				dataStore: 'http://navstore/',
+				version: 5
+			};
+			returnValue = linksData(config);
+		});
+
+		it('creates a Poller with the expected options', () => {
+			assert.calledOnce(Poller);
+			assert.calledWith(Poller, {
+				autostart: true,
+				refreshInterval: 60 * 1000,
+				url: 'http://navstore/v5/links.json'
+			});
+		});
+
+		it('returns the created Poller', () => {
+			assert.strictEqual(returnValue, Poller.mockPoller);
+		});
+
+		describe('when `config.dataStore` has no trailing slash', () => {
+
+			beforeEach(() => {
+				Poller.reset();
+				config.dataStore = 'http://navstore';
+				returnValue = linksData(config);
+			});
+
+			it('creates a Poller with the expected options', () => {
+				assert.calledOnce(Poller);
+				assert.calledWith(Poller, {
+					autostart: true,
+					refreshInterval: 60 * 1000,
+					url: 'http://navstore/v5/links.json'
+				});
+			});
+
+		});
+
+		describe('when `config.dataStore` is not a string', () => {
+
+			it('throws an error', () => {
+				config.dataStore = null;
+				assert.throws(() => linksData(config), 'dataStore must be a string');
+			});
+
+		});
+
+		describe('when `config.version` is not a number', () => {
+
+			it('throws an error', () => {
+				config.version = 'v8';
+				assert.throws(() => linksData(config), 'version must be a number');
+			});
+
+		});
+
+	});
+
+});

--- a/test/unit/lib/navigation-service.js
+++ b/test/unit/lib/navigation-service.js
@@ -9,6 +9,7 @@ describe('lib/navigation-service', () => {
 	let about;
 	let basePath;
 	let healthChecks;
+	let linksData;
 	let navigationData;
 	let navigationService;
 	let origamiService;
@@ -25,6 +26,9 @@ describe('lib/navigation-service', () => {
 
 		healthChecks = require('../mock/health-checks.mock');
 		mockery.registerMock('./health-checks', healthChecks);
+
+		linksData = require('../mock/ft-poller.mock');
+		mockery.registerMock('./links-data', linksData);
 
 		navigationData = require('../mock/ft-poller.mock');
 		mockery.registerMock('./navigation-data', navigationData);
@@ -113,8 +117,20 @@ describe('lib/navigation-service', () => {
 			assert.calledWith(origamiService.mockApp.use, origamiService.middleware.errorHandler.firstCall.returnValue);
 		});
 
+		it('creates a links data poller', () => {
+			assert.called(linksData);
+			assert.calledWith(linksData, {
+				dataStore: options.navigationDataStore,
+				version: 2
+			});
+		});
+
+		it('sets the application `linksDataV2` property to the links data poller', () => {
+			assert.strictEqual(origamiService.mockApp.linksDataV2, linksData.mockPoller);
+		});
+
 		it('creates a navigation data poller', () => {
-			assert.calledOnce(navigationData);
+			assert.called(navigationData);
 			assert.calledWith(navigationData, {
 				dataStore: options.navigationDataStore,
 				version: 2

--- a/views/api.html
+++ b/views/api.html
@@ -58,7 +58,7 @@
 	}
 }</code></pre>
 
-			<h3 id="endpoints-get-v2-menus">GET /v2/menus/<var>:name</var></h3>
+			<h3 id="endpoints-get-v2-menus-name">GET /v2/menus/<var>:name</var></h3>
 
 			<p>
 				Fetch a single menu by name.
@@ -117,6 +117,45 @@
 		}
 	]
 }</code></pre>
+
+			<h3 id="endpoints-get-v2-links">GET /v2/links</h3>
+
+			<p>
+				Fetch all links that the Navigation Service provides as a flat array.
+			</p>
+
+			<div class="o-techdocs-table-wrapper">
+				<table>
+					<tr>
+						<th>Query Param</th>
+						<th>Description</th>
+					</tr>
+					<tr>
+						<td><code>source</code></td>
+						<td>
+							<p>
+								A valid system code which identifies the application making this request.
+							</p>
+						</td>
+					</tr>
+				</table>
+			</div>
+
+			<h4>Response</h4>
+
+			<p>
+				Responds with a JSON array, where each item in the array is an
+				<a href="/v2/docs/api#entity-item">Item entity</a>. E.g.
+			</p>
+
+			<pre><code>GET /v2/links?source=test</code></pre>
+			<pre><code>[
+	{
+		"label": "Example Item",
+		"url": "http://example.com/",
+		"submenu": null
+	}
+]</code></pre>
 
 
 			<h2 id="entities">Entity Types</h2>


### PR DESCRIPTION
This adds the `/v2/links` endpoint which responds with a flat array of every link used across the FT's navigation.