### PR TITLE
Update documentation to use latest majors of Origami components

### DIFF
--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -9,7 +9,7 @@ module.exports = app => {
 	app.get('/v2', cacheControl({maxAge: '7d'}), (request, response) => {
 		navigation.items[0].current = true;
 		response.render('index', {
-			layout: 'main',
+			layout: 'landing',
 			title: 'Origami Navigation Service',
 			navigation
 		});

--- a/public/main.css
+++ b/public/main.css
@@ -5,3 +5,9 @@
 .example-content {
 	padding: 2em
 }
+
+/* Header overrides */
+
+.o-header-services__logo {
+	background-image: url(https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:origami?format=svg&source=origami&width=55);
+}

--- a/public/main.css
+++ b/public/main.css
@@ -1,11 +1,5 @@
 @charset "UTF-8";
 
-/* Additional CSS for the documentation */
-
-.example-content {
-	padding: 2em
-}
-
 /* Header overrides */
 
 .o-header-services__logo {

--- a/views/example.html
+++ b/views/example.html
@@ -1,14 +1,14 @@
-<div class="o-grid-container o-typography-wrapper--product" style="margin-top:20px;">
-	<div class="o-grid-row" >
-		<div data-o-grid-colspan="8 center" class="o-techdocs-content example-content">
+<div class="o-grid-container" style="margin-top:20px;">
+	<div class="o-grid-row">
+		<div data-o-grid-colspan="8 center" class="example-content o-typography-wrapper">
 			<h1>Origami Navigation Service Demo</h1>
 			<p>This page demonstrates how to use <a href="https://github.com/Financial-Times/o-header">o-header</a>, <a href="https://github.com/Financial-Times/o-footer">o-footer</a> and the Origami Navigation Service. The navigation for this page is controlled by the <a href="https://github.com/Financial-Times/origami-navigation-data">Origami Navigation Data</a> repository. When the Origami Navigation Data is updated, the navigation on this page will be updated within 10 minutes.</p>
 
 			<p>The code for this can be found on <a href="https://github.com/Financial-Times/origami-navigation-service/blob/master/lib/routes/v2/docs/example.js">Github</a>.</p>
 
-			<ul style="list-style-type:none;margin-bottom:0;">
+			<ul>
 				{{#navigation.items}}
-				<li><a href="{{href}}">{{name}}</a></li>
+					<li><a href="{{href}}" class="o-typography-link">{{name}}</a></li>
 				{{/navigation.items}}
 			</ul>
 		</div>

--- a/views/index.html
+++ b/views/index.html
@@ -1,17 +1,22 @@
-<h1>Provides consistent navigation for FT applications</h1>
+<div class="o-layout__hero o-layout-typography">
+	<h1>Provides consistent navigation for FT applications</h1>
+	<p>
+		The Origami Navigation Service is a JSON API which provides navigation structures for
+		use across FT websites. Using the service keeps your site consistent and reduces the
+		need for you to manage link updates.
+	</p>
+</div>
 
-<p>
-	The Origami Navigation Service is a JSON API which provides navigation structures for
-	use across FT websites. Using the service keeps your site consistent and reduces the
-	need for you to manage link updates.
-</p>
+<div class="o-layout__main o-layout-typography">
 
-<p>
-	The <a href="docs/api">API documentation</a> outlines how to use the service.
-	If you're migrating from Navigation Service v1, we maintain a
-	<a href="docs/migration">migration guide</a> to help you.
-</p>
+	<p>
+		The <a href="docs/api">API documentation</a> outlines how to use the service.
+		If you're migrating from Navigation Service v1, we maintain a
+		<a href="docs/migration">migration guide</a> to help you.
+	</p>
 
-<p>
-	Here is an <a href="docs/example">example</a> for using this service with <a href="https://registry.origami.ft.com/components/o-header">o-header</a> and <a href="https://registry.origami.ft.com/components/o-header">o-footer</a>.
-</p>
+	<p>
+		Here is an <a href="docs/example">example</a> for using this service with <a href="https://registry.origami.ft.com/components/o-header">o-header</a> and <a href="https://registry.origami.ft.com/components/o-header">o-footer</a>.
+	</p>
+
+</div>

--- a/views/layouts/example.html
+++ b/views/layouts/example.html
@@ -35,7 +35,7 @@
 	</style>
 
 	<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
-	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header@7.5.13,o-footer@^6.0.10,o-grid@^4.4.4,o-typography@^5.7.5" />
+	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header@8.0.5,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2" />
 	<script>
 		(function(src) {
 			if (window.cutsTheMustard) {
@@ -44,7 +44,7 @@
 				var s = document.getElementsByTagName('script')[0];
 				s.parentNode.insertBefore(script, s);
 			}
-		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-grid@^4.4.4,o-header@7.5.13'));
+		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-header@8.0.5,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2'));
 	</script>
 
 </head>

--- a/views/layouts/landing.html
+++ b/views/layouts/landing.html
@@ -5,19 +5,13 @@
 </head>
 <body data-o-component="o-syntax-highlight">
 
-	<div class="o-layout o-layout--docs" data-o-component="o-layout">
+	<div class="o-layout o-layout--landing" data-o-component="o-layout">
 
 		<div class="o-layout__header">
 			{{> header}}
 		</div>
 
-		<div class="o-layout__sidebar">
-			<!-- automatically generated sidebar -->
-		</div>
-
-		<div class="o-layout__main o-layout-typography">
-			{{{body}}}
-		</div>
+		{{{body}}}
 
 		<div class="o-layout__footer">
 			{{> footer}}

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -37,7 +37,7 @@
 			}
 		</style>
 
-		<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^2.0.1,o-fonts@^3.0.4,o-syntax-highlight@^1.5.1,o-table@^6.9.2&brand=internal" />
+		<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-table@^8.0.5&brand=internal" />
 		<link rel="stylesheet" href="main.css" />
 		<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 		<script>
@@ -48,7 +48,7 @@
 					var s = document.getElementsByTagName('script')[0];
 					s.parentNode.insertBefore(script, s);
 				}
-			}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^2.0.1,o-syntax-highlight@^1.5.1'));
+			}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-table@^8.0.5'));
 		</script>
 		<script src="main.js"></script>
 

--- a/views/layouts/main.html
+++ b/views/layouts/main.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 		<title>{{title}}</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<base href="{{basePath}}"/>
 
 		<script>
 			var script = document.createElement('script');

--- a/views/partials/footer.html
+++ b/views/partials/footer.html
@@ -1,4 +1,4 @@
-<footer class="o-layout__footer o-footer-services">
+<footer class="o-footer-services">
 	<div class="o-footer-services__container">
 		<div class="o-footer-services__wrapper o-footer-services__wrapper--top">
 			<a class="o-footer-services__icon-link o-footer-services__icon-link--github" href="http://github.com/financial-times/origami-navigation-service">View project on GitHub</a>

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -1,4 +1,4 @@
-<header class="o-header-services o-layout__header" data-o-component="o-header">
+<header class="o-header-services" data-o-component="o-header">
 	<div class="o-header-services__top o-header-services__container">
 			<div class="o-header-services__ftlogo"></div>
 			<div class="o-header-services__title">

--- a/views/partials/header.html
+++ b/views/partials/header.html
@@ -1,23 +1,27 @@
-<header class="o-header-services" data-o-component="o-header">
-	<div class="o-header-services__top o-header-services__container">
-			<div class="o-header-services__ftlogo"></div>
-			<div class="o-header-services__title">
-				<h1 class="o-header-services__product-name">
-					<a href="/">Origami Navigation Service</a>
-				</h1>
-			</div>
-	</div>
-	<nav class="o-header-services__primary-nav">
-		<div class="o-header-services__container">
-			<ul class="o-layout__primary-nav o-header-services__nav-list">
-				{{#navigation.items}}
-					<li class="o-header-services__nav-item">
-						<a class="o-header-services__nav-link {{#current}}o-header-services__nav-link--selected{{/current}}" href="{{@root.basePath}}{{href}}">
-							{{name}}
-						</a>
-					</li>
-				{{/navigation.items}}
-			</ul>
+<header class="o-header-services" data-o-component="o-header-services">
+
+	<div class="o-header-services__top">
+		<div class="o-header-services__hamburger">
+			<a class="o-header-services__hamburger-icon" href="#" role="button">
+				<span class="o-header-services__visually-hidden">Open primary navigation</span>
+			</a>
 		</div>
+		<div class="o-header-services__logo"></div>
+		<div class="o-header-services__title">
+			<a class="o-header-services__product-name" href="/">Origami Navigation Service</a>
+		</div>
+	</div>
+
+	<nav class="o-header-services__primary-nav" aria-label="primary">
+		<ul class="o-header-services__primary-nav-list">
+			{{#navigation.items}}
+				<li>
+					<a href="{{@root.basePath}}{{href}}" {{#current}}aria-current="true"{{/current}}>
+						{{name}}
+					</a>
+				</li>
+			{{/navigation.items}}
+		</ul>
 	</nav>
+
 </header>

--- a/views/partials/html-head.html
+++ b/views/partials/html-head.html
@@ -2,7 +2,6 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge" />
 <title>{{title}}</title>
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<base href="{{basePath}}"/>
 
 <script>
 	var script = document.createElement('script');
@@ -34,8 +33,8 @@
 	}
 </style>
 
-<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-table@^8.0.5&brand=internal" />
-<link rel="stylesheet" href="main.css" />
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-table@^8.0.5,o-header-services@^4.0.3,o-footer-services@^3.0.2&brand=internal" />
+<link rel="stylesheet" href="{{@root.basePath}}main.css" />
 <script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 <script>
 	(function(src) {
@@ -45,6 +44,6 @@
 			var s = document.getElementsByTagName('script')[0];
 			s.parentNode.insertBefore(script, s);
 		}
-	}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-table@^8.0.5'));
+	}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-table@^8.0.5,o-header-services@^4.0.3,o-footer-services@^3.0.2'));
 </script>
-<script src="main.js"></script>
+<script src="{{@root.basePath}}main.js"></script>

--- a/views/partials/html-head.html
+++ b/views/partials/html-head.html
@@ -1,0 +1,50 @@
+<meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+<title>{{title}}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<base href="{{basePath}}"/>
+
+<script>
+	var script = document.createElement('script');
+	var supportsDeferredScripts = "defer" in script && "async" in script;
+	window.cutsTheMustard = (typeof document.documentElement.dataset === 'object' && ('visibilityState' in document) && supportsDeferredScripts);
+
+	if (window.cutsTheMustard) {
+		document.documentElement.classList.replace('core', 'enhanced');
+	}
+</script>
+
+<style>
+	.core .o--if-js,
+	.enhanced .o--if-no-js {
+		display: none !important;
+	}
+	html {
+		font-family: BentonSans, sans-serif;
+		overflow-x: hidden;
+	}
+	body {
+		margin: 0;
+	}
+	.o-layout__header .o-header-services__top .o-header-services__ftlogo {
+		background-image: url("https://www.ft.com/__origami/service/image/v2/images/raw/ftlogo-v1:origami?source=origami-build-service");
+	}
+	.o-table--row-headings tbody th {
+		width
+	}
+</style>
+
+<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-table@^8.0.5&brand=internal" />
+<link rel="stylesheet" href="main.css" />
+<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
+<script>
+	(function(src) {
+		if (window.cutsTheMustard) {
+			script.async = script.defer = true;
+			script.src = src;
+			var s = document.getElementsByTagName('script')[0];
+			s.parentNode.insertBefore(script, s);
+		}
+	}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-layout@^4.1.6,o-fonts@^4.3.2,o-syntax-highlight@^3.0.1,o-table@^8.0.5'));
+</script>
+<script src="main.js"></script>


### PR DESCRIPTION
I decided to make the home page a landing layout too, I think it's better like this. Resolves #116.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<thead>
<tbody>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/138944/78784843-fa09e400-799d-11ea-86ce-05496520d70e.png" alt="Home page before"/>
</td>
<td>
<img src="https://user-images.githubusercontent.com/138944/78784866-0130f200-799e-11ea-8281-d9aeb17ae2f4.png" alt="Home page after"/>
</td>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/138944/78784946-27569200-799e-11ea-83e1-6c986d52833e.png" alt="API docs page before"/>
</td>
<td>
<img src="https://user-images.githubusercontent.com/138944/78784952-2a518280-799e-11ea-9164-e14c48aaae76.png" alt="API docs page before"/>
</td>
</tr>
<tbody>
</table>