### PR TITLE
Correct example header markup

### DIFF
--- a/lib/routes/v2/docs/example.js
+++ b/lib/routes/v2/docs/example.js
@@ -5,6 +5,7 @@ const requestPromise = require('../../../request-promise');
 const { getPageNavigation } = require('../../../../data/navigation');
 
 let navData;
+const exampleCurrentUrl = '/world/uk';
 
 const breadcrumb = (request, response, next) => {
 
@@ -15,6 +16,18 @@ const breadcrumb = (request, response, next) => {
 	}
 
 	let done = false;
+	const addSelectedPropertyToMenu = (url, menu) => {
+		for (const item of menu.items) {
+			if(item.url === url) {
+				item.selected = true;
+			}
+			if(item.submenu) {
+				item.submenu = addSelectedPropertyToMenu(url, item.submenu);
+			}
+		}
+		return menu;
+	};
+
 	const findUrlInMenu = (url, menu, breadcrumb) => {
 		for (const item of menu.items) {
 			if (item.submenu) {
@@ -40,13 +53,12 @@ const breadcrumb = (request, response, next) => {
 		return breadcrumb;
 	};
 
-	const menus = Object.keys(navData).map(key => navData[key]);
+	const menus = Object.keys(navData).map(
+		key => addSelectedPropertyToMenu(exampleCurrentUrl, navData[key]
+	));
 
 	for (const menu of menus) {
-		// Hard coded for example purposes
-		const breadcrumb = findUrlInMenu('/world/uk', menu, []);
-
-		// const breadcrumb = findUrlInMenu(request.path, menu, []);
+		const breadcrumb = findUrlInMenu(exampleCurrentUrl, menu, []);
 
 		if (breadcrumb.length) {
 			breadcrumb.reverse();

--- a/package-lock.json
+++ b/package-lock.json
@@ -2573,7 +2573,7 @@
     },
     "finalhandler": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
       "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
       "requires": {
         "debug": "2.6.9",
@@ -3590,7 +3590,7 @@
     },
     "jsonfile": {
       "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -3933,7 +3933,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {

--- a/views/layouts/example.html
+++ b/views/layouts/example.html
@@ -25,7 +25,7 @@
 	</style>
 
 	<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
-	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header@8.0.5,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2,o-normalise@2.0.6" />
+	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header@8.4.1,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2,o-normalise@2.0.6" />
 	<script>
 		(function(src) {
 			if (window.cutsTheMustard) {
@@ -34,7 +34,7 @@
 				var s = document.getElementsByTagName('script')[0];
 				s.parentNode.insertBefore(script, s);
 			}
-		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-header@8.0.5,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2,o-normalise@2.0.6'));
+		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-header@8.4.1,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2,o-normalise@2.0.6'));
 	</script>
 
 </head>

--- a/views/partials/example/header.html
+++ b/views/partials/example/header.html
@@ -194,7 +194,7 @@
 								{{/each}}
 								</ul>
 							{{else}}
-								<a class="o-header__drawer-menu-link{{#if variation}} o-header__drawer-menu-link--{{variation}}{{/if}} o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}}>{{label}}</a>
+								<a class="o-header__drawer-menu-link{{#unless ../label }} o-header__drawer-menu-link--secondary{{/unless}}{{#if variation}} o-header__drawer-menu-link--{{variation}}{{/if}} o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}}>{{label}}</a>
 							{{/if}}
 						</li>
 					{{/each}}

--- a/views/partials/example/header.html
+++ b/views/partials/example/header.html
@@ -1,24 +1,18 @@
-<header id="site-navigation" class="o-header" data-o-component="o-header" data-o-header--no-js>
-	<div class="o-header__row o-header__anon" data-trackable="header-anon">
-		<ul class="o-header__anon-list">
-			{{#each navigationLists.navbar-right-anon.items}}
-				<li class="o-header__anon-item">
-					<a class="o-header__anon-link" href="{{url}}" data-trackable="{{label}}">{{label}}</a>
-				</li>
-			{{/each}}
-		</ul>
-	</div>
-	<div class="o-header__row o-header__top" data-trackable="header-top">
+<header class="o-header" data-o-component="o-header" data-o-header--no-js>
+
+	<div class="o-header__row o-header__top">
 		<div class="o-header__container">
 			<div class="o-header__top-wrapper">
-					<div class="o-header__top-column o-header__top-column--left">
-						<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu" aria-controls="o-header-drawer" title="Open drawer menu" data-trackable="drawer-toggle">
-							<span class="o-header__top-link-label">Menu</span>
-						</a>
-						<a href="#o-header-search-primary" class="o-header__top-link o-header__top-link--search" aria-controls="o-header-search-primary" title="Open search bar" data-trackable="search-toggle">
-							<span class="o-header__top-link-label">Search</span>
-						</a>
-					</div>
+				<div class="o-header__top-column o-header__top-column--left">
+					<a href="#o-header-drawer" class="o-header__top-link o-header__top-link--menu"
+						aria-controls="o-header-drawer" title="Open side navigation menu">
+						<span class="o-header__top-link-label">Open side navigation menu</span>
+					</a>
+					<a href="#o-header-search" class="o-header__top-link o-header__top-link--search"
+						aria-controls="o-header-search-js" title="Open search bar">
+						<span class="o-header__top-link-label">Open search bar</span>
+					</a>
+				</div>
 				<div class="o-header__top-column o-header__top-column--center">
 					<a class="o-header__top-logo" href="/" title="Go to Financial Times homepage">
 						<span class="o-header__visually-hidden">Financial Times</span>
@@ -27,39 +21,52 @@
 			</div>
 		</div>
 	</div>
-	<div id="o-header-search-primary" class="o-header__row o-header__search o-header__search--primary" data-o-header-search>
+
+	<div id="o-header-search" class="o-header__row o-header__search o--if-no-js" role="search">
 		<div class="o-header__container">
-			<form class="o-header__search-form" action="/search" role="search" aria-label="Site search" data-typeahead data-typeahead-categories="tags,equities" data-typeahead-view-all>
-				<label class="o-header__visually-hidden" for="o-header-search-term-primary">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__search-term" id="o-header-search-term-primary" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" data-trackable="search-term" placeholder="Search the FT" data-typeahead-input>
-				<button class="o-header__search-submit" type="submit" data-trackable="search-submit">
+			<form class="o-header__search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__search-term" id="o-header-search-term" name="q" type="text" placeholder="Search the FT">
+				<button class="o-header__search-submit" type="submit">
 					Search
 				</button>
-				<button class="o-header__search-close o--if-js" type="button" aria-controls="o-header-search-primary" title="Close search bar">
-					<span class="o-header__visually-hidden">Close</span>
+			</form>
+		</div>
+	</div>
+	<div id="o-header-search-js" class="o-header__row o-header__search" role="search" data-o-header-search>
+		<div class="o-header__container">
+			<form class="o-header__search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-search-term-js">Search the <abbr title="Financial Times">FT</abbr></label>
+				<input class="o-header__search-term" id="o-header-search-term-js" name="q" type="text" placeholder="Search the FT">
+				<button class="o-header__search-submit" type="submit">
+					Search
+				</button>
+				<button class="o-header__search-close o--if-js" type="button" aria-controls="o-header-search-js" title="Close search bar">
+					<span class="o-header__visually-hidden">Close search bar</span>
 				</button>
 			</form>
 		</div>
 	</div>
 
-
-	<nav id="o-header-nav-desktop" class="o-header__row o-header__nav o-header__nav--desktop" role="navigation" aria-label="Primary navigation">
+	<nav id="o-header-nav-desktop" class="o-header__row o-header__nav o-header__nav--desktop" role="navigation"
+		aria-label="Main navigation">
 		<div class="o-header__container">
-			<ul class="o-header__nav-list o-header__nav-list--left" data-trackable="primary-nav">
+
+			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#each navigationLists.navbar-uk.items}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary o-header-nav__list-link--highlight" href="{{url}}" id="o-header-link-{{@index}}" >{{label}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{url}}" id="o-header-link-{{@index}}" {{#if selected}}aria-current="page" aria-label="Current page"{{/if}}>{{label}}</a>
 					{{#if this.submenu}}
 						<div class="o-header__mega" id="o-header-mega-{{@index}}" role="group" aria-labelledby="o-header-link-{{@index}}" data-o-header-mega>
 							<div class="o-header__container">
 								<div class="o-header__mega-wrapper">
-									<div class="o-header__mega-column o-header__mega-column--subsections" data-trackable="sections">
-										<h3 class="o-header__mega-heading">{{label}}</h3>
+									<div class="o-header__mega-column o-header__mega-column--subsections">
+										<div class="o-header__mega-heading">{{label}}</div>
 										<div class="o-header__mega-content">
 											<ul class="o-header__mega-list">
 												{{#each this.submenu.items}}
 													<li class="o-header__mega-item">
-														<a class="o-header__mega-link" href="{{url}}" data-trackable="link">
+														<a class="o-header__mega-link" href="{{url}}">
 															{{label}}
 														</a>
 													</li>
@@ -78,124 +85,129 @@
 	</nav>
 
 	{{#if breadcrumb}}
-		<div class="o-header__subnav" role="navigation" aria-label="Sub navigation" data-o-header-subnav data-trackable="header-subnav">
-			<div class="o-header__container">
-				<div class="o-header__subnav-wrap-outside">
-					<div class="o-header__subnav-wrap-inside" data-o-header-subnav-wrapper>
-						<div class="o-header__subnav-content">
+	<div class="o-header__subnav" role="navigation" aria-label="Sub navigation" data-o-header-subnav>
+		<div class="o-header__container">
+			<div class="o-header__subnav-wrap-outside">
+				<div class="o-header__subnav-wrap-inside" data-o-header-subnav-wrapper>
+					<div class="o-header__subnav-content">
+						{{#if breadcrumb}}
+						<ol class="o-header__subnav-list o-header__subnav-list--breadcrumb" aria-label="Breadcrumb">
+							{{#each breadcrumb}}
+							<li class="o-header__subnav-item">
+								<a class="o-header__subnav-link" href="{{url}}" {{#if selected}}aria-current="page" aria-label="Current page"{{/if}}>
+									{{label}}
+								</a>
+							</li>
+							{{/each}}
+						</ol>
+						{{/if}}
 
-							{{#if breadcrumb}}
-							<ol class="o-header__subnav-list o-header__subnav-list--breadcrumb" aria-label="Breadcrumb" data-trackable="breadcrumb">
-								{{#each breadcrumb}}
-								<li class="o-header__subnav-item">
-									<a class="o-header__subnav-link {{#if selected}}o-header__subnav-link--highlight{{/if}}" href="{{url}}" aria-selected="{{selected}}" data-trackable="{{label}}">
-										{{label}}
-									</a>
-								</li>
-								{{/each}}
-							</ol>
-							{{/if}}
-
-							{{#if subsections}}
-							<ul class="o-header__subnav-list o-header__subnav-list--subsections" aria-label="Subsections" data-trackable="subsections">
-								{{#each subsections.items}}
-								<li class="o-header__subnav-item">
-									<a class="o-header__subnav-link {{#if selected}}o-header__subnav-link--highlight{{/if}}" href="{{url}}" aria-selected="{{selected}}" data-trackable="{{label}}">
-										{{label}}
-									</a>
-								</li>
-								{{/each}}
-							</ul>
-							{{/if}}
-
-						</div>
+						{{#if subsections}}
+						<ul class="o-header__subnav-list o-header__subnav-list--subsections" aria-label="Subsections">
+							{{#each subsections.items}}
+							<li class="o-header__subnav-item">
+								<a class="o-header__subnav-link" href="{{url}}" {{#if selected}}aria-current="page" aria-label="Current page"{{/if}}>
+									{{label}}
+								</a>
+							</li>
+							{{/each}}
+						</ul>
+						{{/if}}
 					</div>
-					<button class="o-header__subnav-button o-header__subnav-button--left" title="scroll left" aria-label="scroll left" aria-hidden="true" disabled></button>
-					<button class="o-header__subnav-button o-header__subnav-button--right" title="scroll right" aria-label="scroll right" aria-hidden="true" disabled></button>
 				</div>
+				<button class="o-header__subnav-button o-header__subnav-button--left" aria-hidden="true" disabled></button>
+				<button class="o-header__subnav-button o-header__subnav-button--right" aria-hidden="true" disabled></button>
 			</div>
 		</div>
+	</div>
 	{{/if}}
 </header>
 
-<div class="o-header__drawer" id="o-header-drawer" role="navigation" aria-label="Drawer menu" data-o-header-drawer data-o-header-drawer--no-js data-trackable="drawer" data-trackable-terminate>
+<div class="o-header__drawer" id="o-header-drawer" role="navigation" aria-label="Drawer menu" data-o-header-drawer
+	data-o-header-drawer--no-js>
 	<div class="o-header__drawer-inner">
 
+
 		<div class="o-header__drawer-tools">
-			<a class="o-header__drawer-tools-logo" href="/" data-trackable="logo">
+			<a class="o-header__drawer-tools-logo" href="/">
 				<span class="o-header__visually-hidden">Financial Times</span>
 			</a>
 
-			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close drawer menu" data-trackable="close">
-				<span class="o-header__visually-hidden">Close</span>
+			<button type="button" class="o-header__drawer-tools-close" aria-controls="o-header-drawer" title="Close side navigation menu">
+				<span class="o-header__visually-hidden">Close side navigation menu</span>
 			</button>
 			<p class="o-header__drawer-current-edition">{{edition}} Edition</p>
 		</div>
 
+
+		{{#if editions}}
+		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
+			<ul class="o-header__drawer-menu-list">
+				{{#each editions}}
+				<li class="o-header__drawer-menu-item"></li>
+					<a class="o-header__drawer-menu-link" href="/?edition={{this}}">Switch to {{this}} Edition</a>
+				</li>
+				{{/each}}
+			</ul>
+		</nav>
+		{{/if}}
+
 		<div class="o-header__drawer-search">
-			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search" data-typeahead data-typeahead-categories="tags,equities" data-typeahead-view-all>
-				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr title="Financial Times">FT</abbr></label>
-				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Search the FT" data-trackable="search-term" data-typeahead-input>
-				<button class="o-header__drawer-search-submit" type="submit" data-trackable="search-submit">
+			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
+				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr
+						title="Financial Times">FT</abbr></label>
+				<input class="o-header__drawer-search-term" id="o-header-drawer-search-term" name="q" type="text"
+					autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"
+					placeholder="Search the FT">
+				<button class="o-header__drawer-search-submit" type="submit">
 					<span class="o-header__visually-hidden">Search</span>
 				</button>
 			</form>
 		</div>
 
-		<nav class="o-header__drawer-menu o-header__drawer-menu--primary o-header__drawer-homepage">
-
-
+		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">
 
-				{{#if editions}}
-					{{#each editions}}
-						<li class="o-header__drawer-menu-item" data-trackable="edition-switcher">
-							<a class="o-header__drawer-menu-link" href="/?edition={{this}}" data-trackable="{{this}}">Switch to {{this}} Edition</a>
-						</li>
-					{{/each}}
-				{{/if}}
-
-			</ul>
-
-			<ul class="o-header__drawer-menu-list">
 				{{#each navigationLists.drawer-uk.items}}
-					{{#if submenu}}
+				{{#if submenu}}
+					{{#if label}}
 						<li class="o-header__drawer-menu-item o-header__drawer-menu-item--heading">
 							{{label}}
 						</li>
-						{{#each submenu.items}}
-							<li class="o-header__drawer-menu-item">
-								{{#if submenu}}
-									<div class="o-header__drawer-menu-toggle-wrapper">
-										{{#if submenu.items}}
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent" href="{url}}" >{{label}}</a>
-										<button class="o-header__drawer-menu-toggle" aria-controls="o-header-drawer-child-{{@index}}" data-trackable="sub-level-toggle | {{label}}">
-											Show more {{label}} links
-										</button>
-										{{/if}}
-									</div>
-									<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{@index}}" data-trackable="sub-level">
-										{{#each submenu.items}}
-											<li class="o-header__drawer-menu-item">
-												<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child" href="{{url}}" >{{label}}</a>
-											</li>
-										{{/each}}
-									</ul>
-								{{else}}
-									<a class="o-header__drawer-menu-link" href="{{url}}" >{{label}}</a>
-								{{/if}}
-							</li>
-						{{/each}}
 					{{/if}}
+					{{#each submenu.items}}
+						<li class="o-header__drawer-menu-item {{#if @first}}{{#unless ../label }} o-header__drawer-menu-item--divide{{/unless}}{{/if}}">
+							{{#if submenu}}
+								<div class="o-header__drawer-menu-toggle-wrapper">
+									{{#if submenu.items}}
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="page"{{/if}}>{{label}}</a>
+									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#if selected}}selected{{else}}unselected{{/if}}" aria-controls="o-header-drawer-child-{{@index}}">
+										Show more {{label}} links
+									</button>
+									{{/if}}
+								</div>
+								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{@index}}">
+								{{#each submenu.items}}
+									<li class="o-header__drawer-menu-item">
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="page"{{/if}}>{{label}}</a>
+									</li>
+								{{/each}}
+								</ul>
+							{{else}}
+								<a class="o-header__drawer-menu-link{{#if variation}} o-header__drawer-menu-link--{{variation}}{{/if}} o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="page"{{/if}}>{{label}}</a>
+							{{/if}}
+						</li>
+					{{/each}}
+				{{/if}}
 				{{/each}}
 			</ul>
 		</nav>
 
-		<nav class="o-header__drawer-menu o-header__drawer-menu--user" data-trackable="user-nav">
+		<nav class="o-header__drawer-menu o-header__drawer-menu--user">
 			<ul class="o-header__drawer-menu-list">
 				{{#each navigationLists.anon.items}}
 					<li class="o-header__drawer-menu-item">
-						<a class="o-header__drawer-menu-link" href="{{replace url "${currentPath}" @root.currentPath}}" data-trackable="{{label}}">
+						<a class="o-header__drawer-menu-link" href="{{replace url "${currentPath}" @root.currentPath}}">
 							{{label}}
 						</a>
 					</li>

--- a/views/partials/example/header.html
+++ b/views/partials/example/header.html
@@ -55,7 +55,7 @@
 			<ul class="o-header__nav-list o-header__nav-list--left">
 				{{#each navigationLists.navbar-uk.items}}
 				<li class="o-header__nav-item">
-					<a class="o-header__nav-link o-header__nav-link--primary" href="{{url}}" id="o-header-link-{{@index}}" {{#if selected}}aria-current="page" aria-label="Current page"{{/if}}>{{label}}</a>
+					<a class="o-header__nav-link o-header__nav-link--primary" href="{{url}}" id="o-header-link-{{@index}}" {{#if selected}}aria-current="page" aria-label="{{label}}, current page"{{/if}}>{{label}}</a>
 					{{#if this.submenu}}
 						<div class="o-header__mega" id="o-header-mega-{{@index}}" role="group" aria-labelledby="o-header-link-{{@index}}" data-o-header-mega>
 							<div class="o-header__container">
@@ -94,7 +94,7 @@
 						<ol class="o-header__subnav-list o-header__subnav-list--breadcrumb" aria-label="Breadcrumb">
 							{{#each breadcrumb}}
 							<li class="o-header__subnav-item">
-								<a class="o-header__subnav-link" href="{{url}}" {{#if selected}}aria-current="page" aria-label="Current page"{{/if}}>
+								<a class="o-header__subnav-link" href="{{url}}" {{#if selected}}aria-current="page" aria-label="{{label}}, current page"{{/if}}>
 									{{label}}
 								</a>
 							</li>
@@ -106,7 +106,7 @@
 						<ul class="o-header__subnav-list o-header__subnav-list--subsections" aria-label="Subsections">
 							{{#each subsections.items}}
 							<li class="o-header__subnav-item">
-								<a class="o-header__subnav-link" href="{{url}}" {{#if selected}}aria-current="page" aria-label="Current page"{{/if}}>
+								<a class="o-header__subnav-link" href="{{url}}" {{#if selected}}aria-current="page" aria-label="{{label}}, current page"{{/if}}>
 									{{label}}
 								</a>
 							</li>
@@ -180,7 +180,7 @@
 							{{#if submenu}}
 								<div class="o-header__drawer-menu-toggle-wrapper">
 									{{#if submenu.items}}
-									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="page"{{/if}}>{{label}}</a>
+									<a class="o-header__drawer-menu-link o-header__drawer-menu-link--parent o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}}>{{label}}</a>
 									<button class="o-header__drawer-menu-toggle o-header__drawer-menu-toggle--{{#if selected}}selected{{else}}unselected{{/if}}" aria-controls="o-header-drawer-child-{{@index}}">
 										Show more {{label}} links
 									</button>
@@ -189,12 +189,12 @@
 								<ul class="o-header__drawer-menu-list o-header__drawer-menu-list--child" id="o-header-drawer-child-{{@index}}">
 								{{#each submenu.items}}
 									<li class="o-header__drawer-menu-item">
-										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="page"{{/if}}>{{label}}</a>
+										<a class="o-header__drawer-menu-link o-header__drawer-menu-link--child o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}}>{{label}}</a>
 									</li>
 								{{/each}}
 								</ul>
 							{{else}}
-								<a class="o-header__drawer-menu-link{{#if variation}} o-header__drawer-menu-link--{{variation}}{{/if}} o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="Current page" aria-current="page"{{/if}}>{{label}}</a>
+								<a class="o-header__drawer-menu-link{{#if variation}} o-header__drawer-menu-link--{{variation}}{{/if}} o-header__drawer-menu-link--{{#if selected}}selected{{else}}unselected{{/if}}" href="{{url}}" {{#if selected}}aria-label="{{label}}, current page" aria-current="page"{{/if}}>{{label}}</a>
 							{{/if}}
 						</li>
 					{{/each}}


### PR DESCRIPTION
Also hide logged in / out elements from the example so to avoid
users copying/pasting items which depend on the users auth state.

Closes https://github.com/Financial-Times/origami-navigation-service/issues/202

Before/after screenshots
<img width="1354" alt="Screenshot 2020-09-21 at 19 06 13" src="https://user-images.githubusercontent.com/10405691/93805081-1ee9cf00-fc3f-11ea-8716-1d65764b3934.png">
<img width="1354" alt="Screenshot 2020-09-21 at 19 06 19" src="https://user-images.githubusercontent.com/10405691/93805082-201afc00-fc3f-11ea-9ea3-d4365f7c5791.png">
<img width="1354" alt="Screenshot 2020-09-21 at 19 06 24" src="https://user-images.githubusercontent.com/10405691/93805084-20b39280-fc3f-11ea-811f-ac8adf84a034.png">
<img width="1354" alt="Screenshot 2020-09-21 at 19 06 29" src="https://user-images.githubusercontent.com/10405691/93805087-214c2900-fc3f-11ea-91d7-722a3deff08b.png">
<img width="861" alt="Screenshot 2020-09-21 at 19 14 02" src="https://user-images.githubusercontent.com/10405691/93805092-227d5600-fc3f-11ea-9f05-f7723763a3e8.png">
<img width="861" alt="Screenshot 2020-09-21 at 19 14 07" src="https://user-images.githubusercontent.com/10405691/93805094-2315ec80-fc3f-11ea-9d29-59414efdbc33.png">
