### PR TITLE
Upgrade o-header example to v8.5.0

### DIFF
--- a/views/layouts/example.html
+++ b/views/layouts/example.html
@@ -25,7 +25,7 @@
 	</style>
 
 	<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
-	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header@8.4.1,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2,o-normalise@2.0.6" />
+	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v2/bundles/css?modules=o-header@^8.5.0,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2,o-normalise@2.0.6" />
 	<script>
 		(function(src) {
 			if (window.cutsTheMustard) {
@@ -34,7 +34,7 @@
 				var s = document.getElementsByTagName('script')[0];
 				s.parentNode.insertBefore(script, s);
 			}
-		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-header@8.4.1,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2,o-normalise@2.0.6'));
+		}('https://www.ft.com/__origami/service/build/v2/bundles/js?modules=o-header@^8.5.0,o-footer@^7.0.5,o-grid@^5.1.1,o-typography@^6.3.2,o-normalise@2.0.6'));
 	</script>
 
 </head>

--- a/views/partials/example/header.html
+++ b/views/partials/example/header.html
@@ -139,19 +139,6 @@
 			<p class="o-header__drawer-current-edition">{{edition}} Edition</p>
 		</div>
 
-
-		{{#if editions}}
-		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
-			<ul class="o-header__drawer-menu-list">
-				{{#each editions}}
-				<li class="o-header__drawer-menu-item"></li>
-					<a class="o-header__drawer-menu-link" href="/?edition={{this}}">Switch to {{this}} Edition</a>
-				</li>
-				{{/each}}
-			</ul>
-		</nav>
-		{{/if}}
-
 		<div class="o-header__drawer-search">
 			<form class="o-header__drawer-search-form" action="/search" role="search" aria-label="Site search">
 				<label class="o-header__visually-hidden" for="o-header-drawer-search-term">Search the <abbr
@@ -164,6 +151,18 @@
 				</button>
 			</form>
 		</div>
+
+		{{#if editions}}
+		<nav class="o-header__drawer-menu" aria-label="Edition switcher">
+			<ul class="o-header__drawer-menu-list">
+				{{#each editions}}
+				<li class="o-header__drawer-menu-item"></li>
+					<a class="o-header__drawer-menu-link" href="/?edition={{this}}">Switch to {{this}} Edition</a>
+				</li>
+				{{/each}}
+			</ul>
+		</nav>
+		{{/if}}
 
 		<nav class="o-header__drawer-menu o-header__drawer-menu--primary">
 			<ul class="o-header__drawer-menu-list">


### PR DESCRIPTION
https://github.com/Financial-Times/o-header/releases/tag/v8.5.0