### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/RUNBOOK.md
+++ b/RUNBOOK.md
@@ -1,6 +1,14 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # Origami Navigation Service
 
 Provides consistent navigation for FT applications.
+
+## Code
+
+origami-navigation-service
 
 ## Service Tier
 
@@ -20,37 +28,19 @@ Heroku
 
 ## Contains Personal Data
 
-no
+No
 
 ## Contains Sensitive Data
 
-no
+No
 
-## Delivered By
+## Can Download Personal Data
 
-origami-team
+No
 
-## Supported By
+## Can Contact Individuals
 
-origami-team
-
-## Known About By
-
-* lee.moody
-* jake.champion
-* rowan.manning
-
-## Dependencies
-
-* origami-navigation-service-data
-* dyn-dns
-* ft-fastly
-* heroku
-
-## Healthchecks
-
-* origami-navigation-service-eu.herokuapp.com-https
-* origami-navigation-service-us.herokuapp.com-https
+No
 
 ## Failover Architecture Type
 
@@ -84,48 +74,58 @@ Manual
 
 This is mostly a Node.js application but with the following external components:
 
-  - An S3 bucket which contains the navigation data as JSON
+*   An S3 bucket which contains the navigation data as JSON
 
 ### Loading Data
 
-1. When this service starts, the first thing it does is fetches a JSON file from an S3 bucket
-2. Having loaded the navigation data, the application can begin serving requests
-3. While running, this application polls the S3 bucket for new data at a regular interval. If the S3 bucket is not available when it's requested, then a stale in-memory copy is served
-
-
+1.  When this service starts, the first thing it does is fetches a JSON file from an S3 bucket
+2.  Having loaded the navigation data, the application can begin serving requests
+3.  While running, this application polls the S3 bucket for new data at a regular interval. If the S3 bucket is not available when it's requested, then a stale in-memory copy is served
 
 ## More Information
 
 See the live service for more information on how to use.
 
+## Heroku Pipeline Name
+
+origami-navigation-service
+
 ## First Line Troubleshooting
 
 There are a few things you can try before contacting the Origami team:
 
-1. Restart all of the dynos across the production EU and US Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/17603799-00d6-4e45-af5c-c21fb88321aa))
+1.  Verify that S3 is up. See [Navigation Data's `__gtg` endpoint](https://www.ft.com/__origami/service/navigation-data/__gtg).
+2.  Restart all of the dynos across the production EU and US Heroku apps ([pipeline here](https://dashboard.heroku.com/pipelines/17603799-00d6-4e45-af5c-c21fb88321aa))
 
 ## Second Line Troubleshooting
 
 If the application is failing entirely, you'll need to check a couple of things:
 
-1. Did a deployment just happen? If so, roll it back to bring the service back up (hopefully)
-2. Check the Heroku metrics page for both EU and US apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/17603799-00d6-4e45-af5c-c21fb88321aa))
-2. Check the Splunk logs (see the monitoring section of this runbook for the link)
+1.  Did a deployment just happen? If so, roll it back to bring the service back up (hopefully)
+2.  Check the Heroku metrics page for both EU and US apps, to see what CPU and memory usage is like ([pipeline here](https://dashboard.heroku.com/pipelines/17603799-00d6-4e45-af5c-c21fb88321aa))
+3.  Check the Splunk logs (see the monitoring section of this runbook for the link)
 
 If only a few things aren't working, the Splunk logs (see monitoring) are the best place to start debugging. Always roll back a deploy if one happened just before the thing stopped working – this gives you the chance to debug in the relative calm of QA.
 
 ## Monitoring
 
-* [Pingdom check (Production EU)][pingdom-eu]: checks that the EU production app is responding
-* [Pingdom check (Production US)][pingdom-us]: checks that the US production app is responding
-* [Sentry dashboard (Production)][sentry-production]: records application errors in the production app
-* [Sentry dashboard (QA)][sentry-qa]: records application errors in the QA app
-* [Splunk (Production)][splunk]: query application logs
+*   [Grafana dashboard][grafana]: graph memory, load, and number of requests
+*   [Pingdom check (Production EU)][pingdom-eu]: checks that the EU production app is responding
+*   [Pingdom check (Production US)][pingdom-us]: checks that the US production app is responding
+*   [Sentry dashboard (Production)][sentry-production]: records application errors in the production app
+*   [Sentry dashboard (QA)][sentry-qa]: records application errors in the QA app
+*   [Splunk (Production)][splunk]: query application logs
+
+[grafana]: http://grafana.ft.com/dashboard/db/origami-navigation-service
 
 [pingdom-eu]: https://my.pingdom.com/newchecks/checks#check=2287222
+
 [pingdom-us]: https://my.pingdom.com/newchecks/checks#check=2287223
+
 [sentry-production]: https://sentry.io/nextftcom/origami-navigation-service-pro/
+
 [sentry-qa]: https://sentry.io/nextftcom/origami-navigation-service-qa/
+
 [splunk]: https://financialtimes.splunkcloud.com/en-US/app/search/search?q=search%20index%3Dheroku%20source%3D%2Fvar%2Flog%2Fapps%2Fheroku%2Forigami-navigation-service-*
 
 ## Failover Details
@@ -144,7 +144,7 @@ The application is deployed to QA whenever a new commit is pushed to the `master
 
 This service uses two keys:
 
-1. GitHub (with read permissions only)
-2. AWS (read/write permissions for a single S3 bucket)
+1.  GitHub (with read permissions only)
+2.  AWS (read/write permissions for a single S3 bucket)
 
 The process for rotating these keys is manual, via the GitHub and AWS interfaces.


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/origami-navigation-service/blob/runbook-no-relationships-2021-03-19/RUNBOOK.md) file has been automatically regenerated from the Biz Ops data for the **origami-navigation-service** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **origami-navigation-service** system in [Biz Ops](https://biz-ops.in.ft.com/System/origami-navigation-service).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
