### PR TITLE
update seconary school link to https://enterprise.ft.com/en-gb/services/group-subscriptions/secondary-education/

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1343,7 +1343,7 @@ links:
 
   - &secondary_schools
     label: "Secondary Schools"
-    url: "https://enterprise.ft.com/en-gb/services/group-subscriptions/education/"
+    url: "https://enterprise.ft.com/en-gb/services/group-subscriptions/secondary-education/"
     submenu:
 
   - &agenda


### PR DESCRIPTION
This was a change requested by Mus