### PR TITLE
 attach all route handlers under the path prefix /__origami/service/navigation/

### DIFF
--- a/lib/navigation-service.js
+++ b/lib/navigation-service.js
@@ -15,7 +15,6 @@ function navigationService(options) {
 
 	const app = origamiService(options);
 
-	app.use(origamiService.middleware.getBasePath());
 	mountRoutes(app);
 	app.use(origamiService.middleware.notFound());
 	app.use(origamiService.middleware.errorHandler());

--- a/lib/routes/home.js
+++ b/lib/routes/home.js
@@ -3,7 +3,10 @@
 module.exports = app => {
 
 	// Service home page
-	app.get('/', (request, response) => {
+	app.get([
+			'/',
+			'/__origami/service/navigation/',
+		], (request, response) => {
 		response.redirect(301, `${request.basePath}v2/`);
 	});
 

--- a/lib/routes/v1/docs.js
+++ b/lib/routes/v1/docs.js
@@ -5,7 +5,10 @@ const httpError = require('http-errors');
 module.exports = app => {
 
 	// v1 endpoint gone
-	app.use('/v1', (request, response, next) => {
+	app.use([
+			'/v1',
+			'/__origami/service/navigation/v1',
+		],(request, response, next) => {
 		const error = httpError(410);
 		error.cacheMaxAge = '7d';
 		next(error);

--- a/lib/routes/v2/docs/api.js
+++ b/lib/routes/v2/docs/api.js
@@ -5,7 +5,10 @@ const { getPageNavigation } = require('../../../../data/navigation');
 
 module.exports = app => {
 	// v2 api documentation page
-	app.get('/v2/docs/api', cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+			'/v2/docs/api',
+			'/__origami/service/navigation/v2/docs/api',
+		], cacheControl({maxAge: '7d'}), (request, response) => {
 		const pageNavData = getPageNavigation();
 		pageNavData.items.find(i => i.id === 'api').current = true;
 

--- a/lib/routes/v2/docs/example.js
+++ b/lib/routes/v2/docs/example.js
@@ -81,7 +81,10 @@ module.exports = app => {
 	});
 
 	// v2 example documentation page
-	app.get('/v2/docs/example', breadcrumb, cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+			'/v2/docs/example',
+			'/__origami/service/navigation/v2/docs/example',
+		],breadcrumb, cacheControl({maxAge: '7d'}), (request, response) => {
 		const pageNavData = getPageNavigation();
 		pageNavData.items.find(i => i.id === 'example').current = true;
 

--- a/lib/routes/v2/docs/migration.js
+++ b/lib/routes/v2/docs/migration.js
@@ -5,7 +5,10 @@ const { getPageNavigation } = require('../../../../data/navigation');
 
 module.exports = app => {
 	// v2 migration page
-	app.get('/v2/docs/migration', cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+			'/v2/docs/migration',
+			'/__origami/service/navigation/v2/docs/migration',
+		], cacheControl({maxAge: '7d'}), (request, response) => {
 		const pageNavData = getPageNavigation();
 		pageNavData.items.find(i => i.id === 'migration').current = true;
 

--- a/lib/routes/v2/index.js
+++ b/lib/routes/v2/index.js
@@ -5,7 +5,10 @@ const { getPageNavigation } = require('../../../data/navigation');
 module.exports = app => {
 
 	// v2 home page
-	app.get('/v2', cacheControl({maxAge: '7d'}), (request, response) => {
+	app.get([
+			'/v2',
+			'/__origami/service/navigation/v2',
+		], cacheControl({maxAge: '7d'}), (request, response) => {
 		const pageNavData = getPageNavigation();
 		pageNavData.items.find(i => i.id === 'overview').current = true;
 

--- a/lib/routes/v2/links.js
+++ b/lib/routes/v2/links.js
@@ -12,8 +12,10 @@ module.exports = app => {
 	});
 
 	// v2 links endpoint
-	app.get(
-		'/v2/links',
+	app.get([
+			'/v2/links',
+			'/__origami/service/navigation/v2/links',
+		],
 		requireValidSourceParam,
 		cacheControl({
 			maxAge: '10m',
@@ -27,8 +29,10 @@ module.exports = app => {
 			response.send(data);
 		}
 	);
-	app.get(
-		'/v2/links.json',
+	app.get([
+			'/v2/links.json',
+			'/__origami/service/navigation/v2/links.json',
+		],
 		cacheControl({
 			maxAge: '10m',
 			staleIfError: '7d'

--- a/lib/routes/v2/menus.js
+++ b/lib/routes/v2/menus.js
@@ -11,8 +11,10 @@ module.exports = app => {
 	});
 
 	// v2 menus endpoint
-	app.get(
-		'/v2/menus',
+	app.get([
+			'/v2/menus',
+			'/__origami/service/navigation/v2/menus',
+		],
 		requireValidSourceParam,
 		cacheControl({
 			maxAge: '10m',
@@ -28,8 +30,10 @@ module.exports = app => {
 	);
 
 	// v2 individual menu endpoint
-	app.get(
-		'/v2/menus/:name',
+	app.get([
+			'/v2/menus/:name',
+			'/__origami/service/navigation/v2/menus/:name',
+		],
 		requireValidSourceParam,
 		cacheControl({
 			maxAge: '10m',

--- a/lib/routes/v2/navigation.js
+++ b/lib/routes/v2/navigation.js
@@ -5,8 +5,10 @@ const navigation = require('../../../build/v2/navigation.json');
 
 module.exports = app => {
 
-	app.get(
-		'/v2/navigation.json',
+	app.get([
+			'/v2/navigation.json',
+			'/__origami/service/navigation/v2/navigation.json',
+		],
 		cacheControl({
 			maxAge: '10m',
 			staleIfError: '7d'

--- a/test/integration/v1/docs.test.js
+++ b/test/integration/v1/docs.test.js
@@ -7,3 +7,8 @@ describe('GET /v1/', function () {
 	setupRequest('GET', '/v1/');
 	itRespondsWithStatus(410);
 });
+
+describe('GET /__origami/service/navigation/v1/', function () {
+	setupRequest('GET', '/__origami/service/navigation/v1/');
+	itRespondsWithStatus(410);
+});

--- a/test/integration/v2/docs.test.js
+++ b/test/integration/v2/docs.test.js
@@ -19,11 +19,9 @@ describe('GET /v2/', function () {
 
 });
 
-describe('GET /v2/ with an FT-Origami-Service-Base-Path header', function() {
+describe('GET /__origami/service/navigation/v2/', function () {
 
-	setupRequest('GET', '/v2/', {
-		'FT-Origami-Service-Base-Path': '/foo/bar/'
-	});
+	setupRequest('GET', '/__origami/service/navigation/v2/');
 	itRespondsWithStatus(200);
 	itRespondsWithContentType('text/html');
 

--- a/test/integration/v2/links.test.js
+++ b/test/integration/v2/links.test.js
@@ -34,3 +34,33 @@ describe('GET /v2/links.json', function () {
 	});
 
 });
+
+describe('GET /__origami/service/navigation/v2/links', function () {
+	setupRequest('GET', '/__origami/service/navigation/v2/links?source=test');
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/json');
+
+	it('responds with the links JSON', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			const json = JSON.parse(response.text);
+			assert.deepEqual(json, require('../../../build/v2/links.json'));
+		}).end(done);
+	});
+
+});
+
+describe('GET /__origami/service/navigation/v2/links.json', function () {
+	setupRequest('GET', '/__origami/service/navigation/v2/links.json');
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/json');
+
+	it('responds with the links JSON', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			const json = JSON.parse(response.text);
+			assert.deepEqual(json, require('../../../build/v2/links.json'));
+		}).end(done);
+	});
+
+});

--- a/test/integration/v2/menus.test.js
+++ b/test/integration/v2/menus.test.js
@@ -71,3 +71,69 @@ describe('GET /v2/menus/:nosourceparam', function() {
 	});
 
 });
+
+describe('GET /__origami/service/navigation/v2/menus', function () {
+
+	setupRequest('GET', '/__origami/service/navigation/v2/menus?source=test');
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/json');
+
+	it('responds with the menu JSON', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			const json = JSON.parse(response.text);
+			// Note: mock data can be found in ../mock/store.js
+			assert.deepEqual(json, menu);
+		}).end(done);
+	});
+
+});
+
+describe('GET /__origami/service/navigation/v2/menus/:validName', function() {
+
+	setupRequest('GET', '/__origami/service/navigation/v2/menus/footer?source=test');
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/json');
+
+	it('responds with the menu JSON', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			const json = JSON.parse(response.text);
+			// Note: mock data can be found in ../mock/store.js
+			assert.deepEqual(json, menu['footer']);
+		}).end(done);
+	});
+
+});
+
+describe('GET /__origami/service/navigation/v2/menus/:invalidName', function() {
+
+	setupRequest('GET', '/__origami/service/navigation/v2/menus/notamenu?source=test');
+	itRespondsWithStatus(404);
+	itRespondsWithContentType('text/html');
+
+	it('responds with an error message', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			// Note: mock data can be found in ../mock/store.js
+			assert.include(response.text, 'Menu &quot;notamenu&quot; was not found');
+		}).end(done);
+	});
+
+});
+
+describe('GET /__origami/service/navigation/v2/menus/:nosourceparam', function() {
+
+	setupRequest('GET', '/__origami/service/navigation/v2/menus/menu1');
+	itRespondsWithStatus(400);
+	itRespondsWithContentType('text/html');
+
+	it('responds with an error message', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			// Note: mock data can be found in ../mock/store.js
+			assert.include(response.text, 'The source parameter is required and must be a valid system code');
+		}).end(done);
+	});
+
+});

--- a/test/integration/v2/navigation.test.js
+++ b/test/integration/v2/navigation.test.js
@@ -20,3 +20,17 @@ describe('GET /v2/navigation.json', function () {
 	});
 
 });
+describe('GET /__origami/service/navigation/v2/navigation.json', function () {
+	setupRequest('GET', '/__origami/service/navigation/v2/navigation.json');
+	itRespondsWithStatus(200);
+	itRespondsWithContentType('application/json');
+
+	it('responds with the navigation JSON', function(done) {
+		this.request.expect(response => {
+			assert.isString(response.text);
+			const json = JSON.parse(response.text);
+			assert.deepEqual(json, navigation);
+		}).end(done);
+	});
+
+});

--- a/test/unit/lib/navigation-service.test.js
+++ b/test/unit/lib/navigation-service.test.js
@@ -84,12 +84,6 @@ describe('lib/navigation-service', () => {
 			assert.strictEqual(options.about, about);
 		});
 
-		it('creates and mounts getBasePath middleware', () => {
-			assert.calledOnce(origamiService.middleware.getBasePath);
-			assert.calledWithExactly(origamiService.middleware.getBasePath);
-			assert.calledWith(origamiService.mockApp.use, origamiService.middleware.getBasePath.firstCall.returnValue);
-		});
-
 		it('loads all of the routes', () => {
 			assert.calledOnce(requireAll);
 			assert.isObject(requireAll.firstCall.args[0]);


### PR DESCRIPTION
this is because the production origami build service is served under www.ft.com/__origami/service/navigation/ and having the application server respond to this path will simplify our cdn configuration

The reason we have added new routes instead of replacing the existing routes is
because when this is deployed it will need to respond to the old routes whilst
we make the changes to the CDN to remove the vcl which remove the path prefix
/__origami/service/navigation/ before making the request to our application servers