### PR TITLE
Add FT Board Director link in Community & Events footer

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1404,10 +1404,19 @@ links:
     url: "https://forums.ft.com/"
     submenu:
 
+  - &ft_board_director_community
+    label: "FT Board Director (community)"
+    url: "https://enterprise.ft.com/board-director-membership"
+    submenu:
+
   - &board_director_programme
     label: "Board Director Programme"
     url: "https://bdp.ft.com/"
     submenu:
+
+  - &board_director_programme_training
+    <<: *board_director_programme
+    label: "Board Director Programme (training)"
 
   - &ft_advisor
     label: "FT Adviser"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -446,7 +446,8 @@ footer:
       - <<: *ft_community
       - <<: *ft_live
       - <<: *ft_forums
-      - <<: *board_director_programme
+      - <<: *ft_board_director_community
+      - <<: *board_director_programme_training
 
 navbar-simple:
   label: Navigation


### PR DESCRIPTION
Update "Community & Events" footer links according to https://financialtimes.atlassian.net/browse/HIVE-516 - adding new [FT Board Director (community) ](https://enterprise.ft.com/board-director-membership) link and changing the existing [Board Director Programme](https://www.bdp.ft.com/) to [Board Director Programme (training)](https://www.bdp.ft.com/)