### PR TITLE
CON-1792 Relabel How to Spend It to HTSI [DO NOT MERGE UNTIL June 1st]

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1435,7 +1435,7 @@ links:
     submenu:
 
   - &how_to_spend_it
-    label: "How to Spend It"
+    label: "HTSI"
     url: "/htsi"
     submenu:
 


### PR DESCRIPTION
This is a branding change to from "How To Spend It" to "HTSI".

I guess they deliberately don't want the meaning of the acronym to be obvious 🤷. Kinda like how 3M, BMW, H&M and YMCA made the original name meaningless to the product (and therefore not troubling) to anyone?