### PR TITLE
Make the myaccount link relative not absolute

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1229,7 +1229,7 @@ links:
 
   - &my_account
     label: "Settings & Account"
-    url: "https://www.ft.com/myaccount"
+    url: "/myaccount"
     submenu:
 
   - &contact_preferences


### PR DESCRIPTION
When running the customer products router and next-profile apps locally this will allow the router to direct the request to the local version of next-profile instead of the production version