### PR TITLE
tweaks to sidebar menu on ft.com

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1387,13 +1387,9 @@ links:
     submenu:
     label: "FT Community"
 
-  - &ft_community_relative
-    <<: *ft_community
-    url: "/tour/community"
-
   - &ft_live
     <<: *conferences_events
-    label: "FT Live"
+    label: "FT Live Events"
 
   - &ft_forums
     label: "FT Forums"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -304,13 +304,9 @@ drawer-uk:
       - <<: *video
       - <<: *podcasts
       - <<: *newsfeed
-      - <<: *ft_community_relative
-        submenu: &ft_community_submenu
-          label:
-          items:
-          - <<: *ft_live
-          - <<: *ft_forums
-          - <<: *board_director_programme
+      - <<: *ft_live
+      - <<: *ft_forums
+      - <<: *board_director_programme
   - label:
     url:
     submenu: &extras_submenu


### PR DESCRIPTION
Issue: [HIVE-1077](https://financialtimes.atlassian.net/browse/HIVE-1077)

### What?
- remove the FT Community nesting and associated styling
- rename “FT Live” to FT Live Events” 
