### PR TITLE
Restore the purge endpoint which currently 404s.

### DIFF
--- a/lib/routes/purge.js
+++ b/lib/routes/purge.js
@@ -22,7 +22,7 @@ module.exports = app => {
 	];
 
 	// Purge page
-	app.post('/purge', purgeUrls({
+	app.post('/__origami/service/navigation/purge', purgeUrls({
 		urls: paths.map(path => `https://www.ft.com/__origami/service/navigation${path}`)
 	}));
 

--- a/test/integration/puge.test.js
+++ b/test/integration/puge.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const itRespondsWithStatus = require('./helpers/it-responds-with-status');
+const setupRequest = require('./helpers/setup-request');
+
+describe('POST /__origami/service/navigation/purge/', function () {
+
+	describe('if no api key is provided', function() {
+		setupRequest('POST', '/__origami/service/navigation/purge/');
+		itRespondsWithStatus(401);
+	});
+
+	describe('if an incorrect api key is provided', function() {
+		setupRequest('POST', '/__origami/service/navigation/purge?apiKey=incorrect');
+		itRespondsWithStatus(403);
+	});
+
+});


### PR DESCRIPTION
This was lost when we updated our CDN to forward the full request path: https://github.com/Financial-Times/origami-navigation-service/commit/a9d72f6df2d5eb3c9a6dab6d22b695f8111caab5

I have added a test to ensure this endpoint does not 404 in the future, however, have not added a test to ensure the purge functionality will work at this time.

Relates to: https://github.com/Financial-Times/origami-navigation-service/issues/572