### PR TITLE
OR-241: update enterprise links to point to new professional subdomain

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1342,14 +1342,14 @@ links:
     url: "http://www.ft.com/products"
     submenu:
 
-  - &group_subscriptions
-    label: "Group Subscriptions"
-    url: "https://enterprise.ft.com/en-gb/services/group-subscriptions/group-contact-us/?segmentId=383c7f63-abf4-b62d-cb33-4c278e6fdf61&cpccampaign=B2B_link_ft.com_footer"
+  - &professional_subscriptions
+    label: "Professional Subscriptions"
+    url: "https://professional.ft.com/en-gb/services/professional-subscriptions?segmentId=383c7f[…]4-b62d-cb33-4c278e6fdf61&cpccampaign=B2B_link_ft.com_footer"
     submenu:
 
   - &republishing
     label: "Republishing"
-    url: "https://enterprise.ft.com/en-gb/services/republishing/"
+    url: "https://professional.ft.com/en-gb/services/republishing/"
     submenu:
 
   - &executive_job_search

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -414,7 +414,7 @@ footer:
       items:
       - <<: *securedrop
       - <<: *individual_subscriptions
-      - <<: *group_subscriptions
+      - <<: *professional_subscriptions
       - <<: *republishing
       - <<: *executive_job_search
       - <<: *advertise_with_the_ft


### PR DESCRIPTION
Please do not merge until 10th July. Speak to the Professional Sales team for further info on when this should be released. See jira tickets for details.