### PR TITLE
Update old footer links

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1374,7 +1374,7 @@ links:
 
   - &advertise_with_the_ft
     label: "Advertise with the FT"
-    url: "http://fttoolkit.co.uk/"
+    url: "https://commercial.ft.com/"
     submenu:
 
   - &ft_twitter
@@ -1389,7 +1389,7 @@ links:
 
   - &currency_converter
     label: "Currency Converter"
-    url: "https://markets.ft.com/research/Markets/Currencies?segid=70113"
+    url: "https://markets.ft.com/data/currencies"
     submenu:
 
   - &ft_channels


### PR DESCRIPTION
fttoolkit.co.uk is a redirect to commercial.ft.com and as it's a non-ft.com domain it's at higher risk of no longer being owned by the FT. Let's just skip the redirect and link to an ft.com subdomain.

The markets.ft.com page is broken and gives a 404. Update the link to a page which is working.