### PR TITLE
Change FT Live Events link in FT recommends

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1347,11 +1347,6 @@ links:
     url: "https://aboutus.ft.com/company/our-standards/editorial-code"
     submenu:
 
-  - &conferences_events
-    label: "FT Live"
-    url: "https://live.ft.com/"
-    submenu:
-
   - &individual_subscriptions
     label: "Individual Subscriptions"
     url: "https://www.ft.com/products"
@@ -1436,10 +1431,6 @@ links:
     url: "https://www.ft.com/tour/community"
     submenu:
     label: "FT Community"
-
-  - &ft_live
-    <<: *conferences_events
-    label: "FT Live Events"
 
   - &ft_live_events
     label: "FT Live Events"

--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1441,6 +1441,11 @@ links:
     <<: *conferences_events
     label: "FT Live Events"
 
+  - &ft_live_events
+    label: "FT Live Events"
+    url: "https://events.ft.com/events-list "
+    submenu:
+
   - &ft_forums
     label: "FT Forums"
     url: "https://forums.ft.com/"

--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1443,7 +1443,7 @@ links:
 
   - &ft_live_events
     label: "FT Live Events"
-    url: "https://events.ft.com/events-list "
+    url: "https://events.ft.com/events-list"
     submenu:
 
   - &ft_forums

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -309,7 +309,7 @@ drawer-uk:
       - <<: *video
       - <<: *podcasts
       - <<: *newsfeed
-      - <<: *ft_live
+      - <<: *ft_live_events
       - <<: *ft_forums
       - <<: *board_director_programme
   - label:

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -448,7 +448,7 @@ footer:
       label:
       items:
       - <<: *ft_community
-      - <<: *ft_live
+      - <<: *ft_live_events
       - <<: *ft_forums
       - <<: *ft_board_director
       - <<: *board_director_programme


### PR DESCRIPTION
JIRA ticket: [HIVE-1368](https://financialtimes.atlassian.net/browse/HIVE-1368)

Add new `ft_live_events` in `links.yaml`  and use it in place of `ft_live` under `FT recommends` submenu

[HIVE-1368]: https://financialtimes.atlassian.net/browse/HIVE-1368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ