### PR TITLE
add Digital Edition to navbar-right

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1192,6 +1192,11 @@ links:
     url: "/banking-savings"
     submenu:
 
+  - &digital_edition
+    label: "Digital Edition"
+    url: "https://www.ft.com/todaysnewspaper"
+    submenu:
+
   - &epaper
     label: "Today’s Newspaper (FT Digital Edition)"
     url: "https://www.ft.com/todaysnewspaper"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -463,6 +463,7 @@ navbar-simple:
 navbar-right:
   label: Navigation
   items:
+  - <<: *digital_edition
   - <<: *portfolio
   - <<: *my_account
 


### PR DESCRIPTION
USG ran a (n inconclusive) test, adding a link to the `ePaper` on the righthand nav bar.  This is now called the Digital Edition, and needs a longer term home as the decision was made to keep it in the nav.  

[Ticket](https://financialtimes.atlassian.net/jira/software/c/projects/UG/boards/1128?modal=detail&selectedIssue=UG-1077)
