### PR TITLE
Preparation for Cookie-Management-Platform integration, re-labling ex…

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1363,8 +1363,13 @@ links:
     submenu:
 
   - &cookies
-    label: "Cookies"
+    label: "Cookie Policy"
     url: "https://help.ft.com/help/legal-privacy/cookies/"
+    submenu:
+
+  - &cookies
+    label: "Manage Cookies"
+    url: "https://www.ft.com/preferences/manage-cookies"
     submenu:
 
   - &copyright

--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1367,7 +1367,7 @@ links:
     url: "https://help.ft.com/help/legal-privacy/cookies/"
     submenu:
 
-  - &cookies
+  - &cookies_management
     label: "Manage Cookies"
     url: "https://www.ft.com/preferences/manage-cookies"
     submenu:

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -415,6 +415,7 @@ footer:
       - <<: *terms_conditions
       - <<: *privacy
       - <<: *cookies
+      - <<: *cookies_management
       - <<: *copyright
       - <<: *slavery_statement
   - label: Services


### PR DESCRIPTION
Preparation for Cookie-Management-Platform integration.
 * Re-labelling existing 'Cookies' link to be 'Cookie Policy'.
 * Adding new link labelled  'Manage Cookies' linking to the manage cookies preference page.
 
See https://financialtimes.atlassian.net/jira/software/c/projects/ADSDEV/boards/803?selectedIssue=ADSDEV-1491 for further details.