### PR TITLE
HIVE-1769. Change Board Director label and link on FT.com footer

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1497,9 +1497,9 @@ links:
     url: "https://forums.ft.com/"
     submenu:
 
-  - &ft_board_director
-    label: "FT Board Director"
-    url: "https://enterprise.ft.com/board-director-membership"
+  - &ft_board_network
+    label: "FT Board Network"
+    url: "https://forums.ft.com/ft-board-network"
     submenu:
 
   - &board_director_programme

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -464,7 +464,7 @@ footer:
       - <<: *ft_community
       - <<: *ft_live_events
       - <<: *ft_forums
-      - <<: *ft_board_director
+      - <<: *ft_board_network
       - <<: *board_director_programme
 
 navbar-simple:


### PR DESCRIPTION
## Ticket 
https://financialtimes.atlassian.net/browse/HIVE-1796

## Requirements
- change link for FT Board Director label on ft.com footer to be https://forums.ft.com/ft-board-network
- change FT Board Director label to be FT Board Network