### PR TITLE
Add FT App & FT Edit to tools list [OR-481]

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1051,12 +1051,12 @@ links:
     label: "Vancouver"
     url: "/globetrotter/vancouver"
     submenu:
-  
+
   - &globetrottermilan
     label: "Milan"
     url: "/globetrotter/milan"
     submenu:
-  
+
   - &globetrotterzurich
     label: "Zurich"
     url: "/globetrotter/zurich"
@@ -1238,12 +1238,7 @@ links:
     submenu:
 
   - &digital_edition
-    label: "Digital Edition"
-    url: "https://www.ft.com/todaysnewspaper"
-    submenu:
-
-  - &epaper
-    label: "Today’s Newspaper (FT Digital Edition)"
+    label: "FT Digital Edition"
     url: "https://www.ft.com/todaysnewspaper"
     submenu:
 
@@ -1275,6 +1270,16 @@ links:
   - &apps
     label: 'Our Apps'
     url: 'https://www.ft.com/tour/apps'
+    submenu:
+
+  - &ft_app
+    label: 'Our Apps'
+    url: 'https://applink.ft.com/A6lV/2khsqyrh'
+    submenu:
+
+  - &ft_edit
+    label: 'FT Edit'
+    url: 'https://ftedit.ft.com/Ju3k/pqkac2ds'
     submenu:
 
   - &tools_services

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -329,7 +329,7 @@ drawer-uk:
       items:
       - <<: *my_ft
       - <<: *portfolio
-      - <<: *epaper
+      - <<: *digital_edition
       - <<: *crossword
       - <<: *apps
 
@@ -442,7 +442,11 @@ footer:
       items:
       - <<: *portfolio
         submenu:
-      - <<: *epaper
+      - <<: *ft_app
+        submenu:
+      - <<: *digital_edition
+        submenu:
+      - <<: *ft_edit
         submenu:
       - <<: *alerts_hub
         submenu:


### PR DESCRIPTION
This way all apps are represented. Following the links from mobile, we would like to skip the stage where users are directed to the app pages so we are directing them to the relevant App Store. Requested by Anxhela Berisha and approved by Megan Dold in the comms team