### PR TITLE
correct ft app link

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1273,7 +1273,7 @@ links:
     submenu:
 
   - &ft_app
-    label: 'Our Apps'
+    label: 'FT App'
     url: 'https://applink.ft.com/A6lV/2khsqyrh'
     submenu:
 


### PR DESCRIPTION
Relates to https://github.com/Financial-Times/origami-navigation-service/pull/854