### PR TITLE
chore: Remove polyfill.io use

### DIFF
--- a/views/layouts/example.html
+++ b/views/layouts/example.html
@@ -24,7 +24,6 @@
 		}
 	</style>
 
-	<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 	<link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-header@^11.0.0,o-footer@^9.0.0,o-grid@^6.1.5,o-typography@^7.3.2,o-normalise@^3.2.2,o-autoinit@^3.1.3&brand=core&system_code=origami-navigation-service" />
 	<script>
 		(function(src) {

--- a/views/partials/html-head.html
+++ b/views/partials/html-head.html
@@ -25,7 +25,6 @@
 
 <link rel="stylesheet" href="https://www.ft.com/__origami/service/build/v3/bundles/css?components=o-layout@^5.2.3,o-fonts@^5.3.3,o-syntax-highlight@^4.2.3,o-table@^9.2.5,o-header-services@^5.2.3,o-footer-services@^4.2.3,o-autoinit@^3.1.3,o-normalise@^3.0.0&brand=internal&system_code=origami-navigation-service" />
 <link rel="stylesheet" href="{{@root.basePath}}main.css" />
-<script src="https://polyfill.io/v2/polyfill.min.js?features=fetch,default"></script>
 <script>
 	(function(src) {
 		if (window.cutsTheMustard) {


### PR DESCRIPTION
Polyfill has not been FT owned for awhile, and has recently been sold. We are able to meet our browser support policy without it.