### PR TITLE
removed ft_board_network from the links and the navigation

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1517,11 +1517,6 @@ links:
     url: "https://forums.ft.com/"
     submenu:
 
-  - &ft_board_network
-    label: "FT Board Network"
-    url: "https://forums.ft.com/ft-board-network"
-    submenu:
-
   - &board_director_programme
     label: "Board Director Programme"
     url: "https://bdp.ft.com/"

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -471,7 +471,6 @@ footer:
       - <<: *ft_community
       - <<: *ft_live_events
       - <<: *ft_forums
-      - <<: *ft_board_network
       - <<: *board_director_programme
 
 navbar-simple:


### PR DESCRIPTION
After requestion for removing an invalid link from the navigation