### PR TITLE
My Account / myFT header entry point improvements

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1358,7 +1358,7 @@ links:
     submenu:
 
   - &my_ft
-    label: "myFT"
+    label: "myFT Feed"
     url: "/myft"
     submenu:
 

--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1348,7 +1348,7 @@ links:
     submenu:
 
   - &my_account
-    label: "Settings & Account"
+    label: "My Account"
     url: "/myaccount"
     submenu:
 

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -485,7 +485,7 @@ navbar-right:
   items:
   - <<: *digital_edition
   - <<: *portfolio
-  - <<: *my_account
+  - <<: *my_ft
 
 
 navbar-right-anon:

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -487,13 +487,23 @@ navbar-right:
   - <<: *portfolio
   - <<: *my_ft
 
+navbar-top-right:
+  label: Navigation
+  items:
+  - <<: *my_account
+  - <<: *header_subscribe
 
-navbar-right-anon:
+# To make the data better reflect the o-header markup
+# We are introducing a new navbar-top-right-anon object
+# As the navbar-right object is used for the right bottom row
+# For backwards compatibility we have kept navbar-right-anon as well
+navbar-top-right-anon: &navbar-top-right-anon
   label: Navigation
   items:
   - <<: *sign_in
   - <<: *header_subscribe
 
+navbar-right-anon: *navbar-top-right-anon
 
 navbar-uk:
   label: Navigation


### PR DESCRIPTION
### Description

Update the data to reflect improvements to the header for the My Account and myFT links

### Justification

In early 2024 the Retention team ran an AB test to try and improve the user experience of the header by trying to reduce confusion of the difference between Settings & Account and myFT. This test was successful so we are now rolling these changes out to all users. The changes that are relevant to this PR are

1. Rename `Settings & Account` to `My Account`
2. Rename `myFT` to `myFT Feed`
3. Move My Account to the top right slot, replacing the myFT logo
4. Move myFT to the bottom right slot, replacing the old Settings & Account link


### Screenshots
 
 **Anonymous user - Previous layout**

![Screenshot of the FT header as seen by an anonymous user in the test control](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/e4400267-c55c-4ad1-8ba7-d21db826423b)
 
  **Anonymous user - New layout**  
  
![Screenshot of the FT header as seen by an anonymous user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/70e9aa8b-6228-480f-97b2-37eba0ef1ab6)

  **Signed in user - Previous layout**
  
  
![Screenshot of the FT header as seen by an registered user in the test control](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/210f0b4d-c815-4339-a436-a197fb6aa783)

  **Signed in user - New layout**
  
![Screenshot of the FT header as seen by an regustered user in the test variant](https://github.com/Financial-Times/dotcom-page-kit/assets/524573/b24475f5-6c76-4e72-8499-ecb3d85ca6dc)

