### PR TITLE
ENT-1804 Rename Enterprise Tools footer entry to Subscription Manager and update link

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1613,9 +1613,9 @@ links:
     url: "https://help.ft.com/help/legal/slavery-statement/"
     submenu:
 
-  - &enterprise_tools
-    label: "Enterprise Tools"
-    url: "https://kat.ft.com/"
+  - &subscription_manager
+    label: "Subscription Manager"
+    url: "https://subscription-manager.ft.com/"
     submenu:
 
   - &about_us_careers

--- a/data/navigation.yaml
+++ b/data/navigation.yaml
@@ -457,7 +457,7 @@ footer:
         submenu:
       - <<: *business_school_rankings
         submenu:
-      - <<: *enterprise_tools
+      - <<: *subscription_manager
         submenu:
       - <<: *newsfeed
         submenu:


### PR DESCRIPTION
https://financialtimes.atlassian.net/browse/ENT-1804

> As part of the FT Professional rebranding in 2023, Enterprise Tools was renamed to Subscription Manager. This PR renames the entry