### PR TITLE
chore: rename myFT feed to myft

### DIFF
--- a/data/links.yaml
+++ b/data/links.yaml
@@ -1368,7 +1368,7 @@ links:
     submenu:
 
   - &my_ft
-    label: "myFT Feed"
+    label: "myFT"
     url: "/myft"
     submenu:
 


### PR DESCRIPTION
We recently introduced the "Feed" wording to the myFT link However on speaking to FT Professional they would prefer it to be just myft.

Their reason is that when B2B customers click on this link they are redirected to the B2B personalisation tool (workspace) and therefore the Feed wording makes it more confusing